### PR TITLE
Add app-icon

### DIFF
--- a/components/app-icon/app-icon.vue
+++ b/components/app-icon/app-icon.vue
@@ -1,6 +1,6 @@
 <template>
   <img
-    :src="`/assets/icons/${name}`"
+    :src="`/assets/icons/${name}.svg`"
     alt=""
     class="app-icon"
   />

--- a/components/app-icon/app-icon.vue
+++ b/components/app-icon/app-icon.vue
@@ -1,0 +1,25 @@
+<template>
+  <img
+    :src="`/assets/icons/${name}`"
+    alt=""
+    class="app-icon"
+  />
+</template>
+
+<script>
+  export default {
+    props: {
+      name: {
+        type: String,
+        required: true
+      }
+    },
+  }
+</script>
+
+<style>
+  .app-icon {
+    height: 1em;
+    width: 1em;
+  }
+</style>


### PR DESCRIPTION
## Wat is er gedaan?
App icon component gebouwd. Is een simpele afbeelding die al linkt naar `/assets/icons/${name}`, de naam kan je dus als prop meegeven. Heeft een lege alt tekst zodat de contents van de afbeelding niet gelezen worden als de gebruiker er overheen gaat met tab.

## Hoe te testen?
Ga er maar vanuit dat dit werkt ❤️ 
