### PR TITLE
Add fixed-ratio component

### DIFF
--- a/components/fixed-ratio/fixed-ratio.vue
+++ b/components/fixed-ratio/fixed-ratio.vue
@@ -1,0 +1,48 @@
+<template>
+  <div
+    class="fixed-ratio"
+    :style="`padding-bottom: ${this.ratio}%`"
+  >
+    <div class="fixed-ratio__content">
+      <slot />
+    </div>
+  </div>
+</template>
+
+<script>
+  export default {
+    props: {
+      height: {
+        type: Number,
+        required: true
+      },
+      width: {
+        type: Number,
+        required: true
+      }
+    },
+    computed: {
+      ratio() {
+        return this.height / this.width * 100
+      }
+    }
+  }
+</script>
+
+<style>
+  .fixed-ratio {
+    display: block;
+    position: relative;
+	  overflow: hidden;
+	  background-color: #eee;
+  }
+
+  .fixed-ratio__content {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    max-width: inherit;
+  }
+</style>


### PR DESCRIPTION
## Wat is er gedaan?
Fixed ratio component gebouwd dat image reflow voorkomt. We kunnen de aspect ratio aangeven met een `height` en `width` prop. [Wat is image reflow?](https://www.voorhoede.nl/en/blog/say-no-to-image-reflow/)

## Hoe te testen?
Again, ga er maar vanuit dat dit werkt ❤️
