### PR TITLE
Add app icon with counter

### DIFF
--- a/components/app-icon-with-counter/app-icon-with-counter.vue
+++ b/components/app-icon-with-counter/app-icon-with-counter.vue
@@ -1,0 +1,64 @@
+<template>
+  <figure class="app-icon-with-counter">
+    <img
+      :src="`~/assets/icons/${name}`"
+      alt=""
+    >
+    <transition name="fade">
+      <figcaption
+        v-if="isShown"
+        class="app-icon-with-counter__label-container"
+      >
+        <dl>
+          <dt class="sr-only">{{ message }}</dt>
+          <dd class="app-icon-with-counter__label">{{ amount }}</dd>
+        </dl>
+      </figcaption>
+    </transition>
+  </figure>
+</template>
+
+<script>
+  export default {
+    props: {
+      name: {
+        type: String,
+        required: true
+      },
+      message: {
+        type: String,
+        default: ''
+      },
+      amount: {
+        type: Number,
+        required: true
+      }
+    },
+    computed: {
+      isShown() {
+        return this.amount > 0;
+      }
+    }
+  }
+</script>
+
+<style>
+  .app-icon-with-counter {
+    position: relative;
+    margin-right: 5px;
+  }
+
+  .app-icon-with-counter__label-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    position: absolute;
+    top: -5px;
+    right: -5px;
+    background-color: var(--color-lightest);
+    border-radius: 50%;
+    height: 20px;
+    width: 20px;
+
+  }
+</style>

--- a/components/app-icon/app-icon.vue
+++ b/components/app-icon/app-icon.vue
@@ -1,6 +1,6 @@
 <template>
   <img
-    :src="`/assets/icons/${name}.svg`"
+    :src="`~/assets/icons/${name}.svg`"
     alt=""
     class="app-icon"
   />

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -11,5 +11,65 @@
 </script>
 
 <style>
+  :root {
+    --color-darkest: #1D2939;
+    --color-lightest: #F2F2F2;
+    --color-gray: #E6E6E6;
+    --color-highlight-yellow: #FAFF2E;
+    --color-highlight-red: #F65645;
+    --color-highlight-green: #1BEAAE;
+    --color-highlight-purple: #6B38E8;
+    --color-dimmed-purple: #D8CEDB;
+  }
 
+  /*
+    CSS Reset
+    http://meyerweb.com/eric/tools/css/reset/
+    v2.0 | 20110126
+    License: none (public domain)
+  */
+
+  html, body, div, span, applet, object, iframe,
+  h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+  a, abbr, acronym, address, big, cite, code,
+  del, dfn, em, img, ins, kbd, q, s, samp,
+  small, strike, strong, sub, sup, tt, var,
+  b, u, i, center,
+  dl, dt, dd, ol, ul, li,
+  fieldset, form, label, legend,
+  table, caption, tbody, tfoot, thead, tr, th, td,
+  article, aside, canvas, details, embed,
+  figure, figcaption, footer, header, hgroup,
+  menu, nav, output, ruby, section, summary,
+  time, mark, audio, video {
+    margin: 0;
+    padding: 0;
+    border: 0;
+    font-size: 100%;
+    font: inherit;
+    vertical-align: baseline;
+  }
+  /* HTML5 display-role reset for older browsers */
+  article, aside, details, figcaption, figure,
+  footer, header, hgroup, menu, nav, section {
+    display: block;
+  }
+  body {
+    line-height: 1;
+  }
+  ol, ul {
+    list-style: none;
+  }
+  blockquote, q {
+    quotes: none;
+  }
+  blockquote:before, blockquote:after,
+  q:before, q:after {
+    content: '';
+    content: none;
+  }
+  table {
+    border-collapse: collapse;
+    border-spacing: 0;
+  }
 </style>


### PR DESCRIPTION
## Wat is er gedaan?
Een app icon met countertje toegevoegd om het winkelmandje te kunnen tonen met een bolletje met het aantal items in je winkelmandje. Ook een bugje gefixt in `app-icon`, path naar assets moet een tilde hebben ervoor

## Hoe te testen?
Ga er maar vanuit dat het werkt, if not, we change later ❤️ 
