### PR TITLE
Fix/loading carecompanies

### DIFF
--- a/src/components/company-search/company-search.vue
+++ b/src/components/company-search/company-search.vue
@@ -15,16 +15,24 @@
       v-if="autocompleteIsEnabled"
       class="company-search__autocomplete"
     >
-      <button
-        type="button"
-        class="company-search__autocomplete-item correct-casing"
-        v-for="(company, i) in matchingCompanies"
-        :key="`${company.id}-${i}`"
-        @click="onCompanyClick(company)"
-        :disabled="isPending"
+      <div v-if="careCompanies">
+        <button
+          type="button"
+          class="company-search__autocomplete-item correct-casing"
+          v-for="(company, i) in matchingCompanies"
+          :key="`${company.id}-${i}`"
+          @click="onCompanyClick(company)"
+          :disabled="isPending"
+        >
+          {{ company.naam }}
+        </button>
+      </div>
+      <p
+        v-else
+        class="company-search__autocomplete-text"
       >
-        {{ company.naam }}
-      </button>
+        Zorgbedrijven laden...
+      </p>
     </div>
   </div>
 </template>
@@ -179,5 +187,9 @@
 
   .company-search__autocomplete-item:disabled {
     color: $color-gray;
+  }
+
+  .company-search__autocomplete-text {
+    padding: $spacing-default;
   }
 </style>


### PR DESCRIPTION
## Wat is er gedaan?
Een loading state toegevoegd aan de autocomplete voor als er nog geen zorgbedrijven geladen zijn. 'T is in wezen een soort pleister omdat we dat inladen misschien nog wel mooier kunnen fixen met een JSON server o.i.d. this will do voor MVP

## Hoe te testen?
Open de deploy preview en klik direct op het input, er komt dan 'Zorgbedrijven laden...' te staan. Zodra die geladen zijn moet die tekst vervangen worden door de zorgbedrijven.
