### PR TITLE
Fix/percentages to fixed

### DIFF
--- a/src/components/bar-chart/bar-chart.js
+++ b/src/components/bar-chart/bar-chart.js
@@ -66,7 +66,7 @@ export default {
       if (selectedProperty === 'omzetPerFte') {
         return '€' + Math.round(datalabel / 1000) + 'K'
       } else {
-        return Math.round(datalabel) + '%'
+        return ((Math.round(datalabel*100)/100).toFixed(1) + '%')
       }
     }
 

--- a/src/components/bar-chart/bar-chart.js
+++ b/src/components/bar-chart/bar-chart.js
@@ -183,11 +183,16 @@ export default {
 
 function checkProperty(datalabel, selectedProperty) {
   if (selectedProperty === 'omzetPerFte') {
-    return '€' + Math.round(datalabel / 1000) + 'K'
+    const abbrNumberThousand = Math.round(datalabel / 1000)
+    return '€' + abbrNumberThousand + 'K'
   } else {
-    return Math.round(datalabel) + '%'
+    // multiplied by 100 to prevent Math.round from filtering out the decimals beforehand
+    const roundedPercentage = Math.round(datalabel*100)/100
+    const fixedPercentage = roundedPercentage.toFixed(1)
+    return fixedPercentage + '%'
   }
 }
+
 
 // will move this funciton to libs (Deanna)
 function capitalize(label) {


### PR DESCRIPTION
## Wat is er gedaan?
Percentages worden nu weergeven met één decimaal achter de komma.

## Hoe te testen?
Selecteer een bedrijf+jaar en check de bar charts 

## Quirks (if applicable)
Die van 'gemiddelde' wil ik eigenlijk onafgerond hebben..